### PR TITLE
feature/Server auto configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,12 @@ sources:
 Server auto configuration allows for dynamic resolution of parameters like `kumuluzee.openapi-mp.ui.specification-server` 
 instead of need to set it. This is done by retrieving necessary information from request during runtime and based on that 
 setting correct redirect. It is especially useful when service is being deployed in multiple environments.
-This feature also updates list of servers in Swagger UI and set order (if enabled).
+This feature also updates list of servers in Swagger UI and reorder them, so it will be first one.
 It is also possible to resolve correct redirect when service is behind for example Ingres (Ingress must have enabled feature which 
-forwards original URL) 
+forwards original URL).
 
 By default, this feature is disabled for backward compatibility. To enable it set `kumuluzee.openapi-mp.ui.auto-config.enabled`
-to `true`. To enable (Ingress) URI check set `kumuluzee.openapi-mp.ui.auto-config.original-uri-check` to `true` and to disable server 
-list update set `kumuluzee.openapi-mp.ui.auto-config.update-servers` to `false`.
+to `true`. To enable (Ingress) URI check set `kumuluzee.openapi-mp.ui.auto-config.original-uri-check` to `true`.
 
 Default settings for server auto configuration:
 ```yaml
@@ -185,11 +184,10 @@ kumuluzee:
     ui:
       server-auto-config:
         enabled: false
-        update-servers: true
         original-uri-check: false
 ```
 
-> **note:** localhost server is added only once (if not already specified in @OpenAPIDefinition) and in case in which 
+> **note:** localhost server with same port is added only once (if not already specified in @OpenAPIDefinition) and in case in which 
 > is used localhost address in different format (for example http://127.0.0.1:8080 instead of http://localhost:8080), 
 >no new server will be added to list and because of this Swagger UI will be unable to do API calls (this is due to issue with cors) 
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,34 @@ sources:
 1. Configuration property: `kumuluzee.server.base-url` (useful for overriding above values)
 1. Configuration property: `kumuluzee.openapi-mp.ui.specification-server` (same as above but in a namespace specific to
    this extension)
+   
+## Swagger UI server auto configuration
+
+Server auto configuration allows for dynamic resolution of parameters like `kumuluzee.openapi-mp.ui.specification-server` 
+instead of need to set it. This is done by retrieving necessary information from request during runtime and based on that 
+setting correct redirect. It is especially useful when service is being deployed in multiple environments.
+This feature also updates list of servers in Swagger UI and set order (if enabled).
+It is also possible to resolve correct redirect when service is behind for example Ingres (Ingress must have enabled feature which 
+forwards original URL) 
+
+By default, this feature is disabled for backward compatibility. To enable it set `kumuluzee.openapi-mp.ui.auto-config.enabled`
+to `true`. To enable (Ingress) URI check set `kumuluzee.openapi-mp.ui.auto-config.original-uri-check` to `true` and to disable server 
+list update set `kumuluzee.openapi-mp.ui.auto-config.update-servers` to `false`.
+
+Default settings for server auto configuration:
+```yaml
+kumuluzee:
+  openapi-mp:
+    ui:
+      server-auto-config:
+        enabled: false
+        update-servers: true
+        original-uri-check: false
+```
+
+> **note:** localhost server is added only once (if not already specified in @OpenAPIDefinition) and in case in which 
+> is used localhost address in different format (for example http://127.0.0.1:8080 instead of http://localhost:8080), 
+>no new server will be added to list and because of this Swagger UI will be unable to do API calls (this is due to issue with cors) 
 
 ## Changelog
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
         <smallrye-open-api.version>1.2.1</smallrye-open-api.version>
         <classgraph.version>4.8.39</classgraph.version>
-        <swagger-ui.version>3.22.3</swagger-ui.version>
+        <swagger-ui.version>3.25.1</swagger-ui.version>
 
         <testng.version>6.9.9</testng.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
         <swagger-ui.version>3.25.1</swagger-ui.version>
 
         <testng.version>6.9.9</testng.version>
+        <org.mockito.version>3.3.3</org.mockito.version>
+        <assertj.version>3.15.0</assertj.version>
 
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <nexus.staging.plugin.version>1.6.8</nexus.staging.plugin.version>
@@ -46,6 +48,8 @@
         <surefire.plugin.version>2.22.1</surefire.plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <download-maven-plugin.version>1.4.2</download-maven-plugin.version>
+
+        <guava.version>29.0-jre</guava.version>
     </properties>
 
     <scm>
@@ -109,6 +113,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.eclipse.microprofile.openapi</groupId>
                 <artifactId>microprofile-openapi-tck</artifactId>
                 <version>${microprofile-openapi.version}</version>
@@ -124,6 +134,18 @@
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${org.mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -29,6 +29,26 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ui/src/main/java/com/kumuluz/ee/openapi/mp/ui/OpenApiMpUiExtension.java
+++ b/ui/src/main/java/com/kumuluz/ee/openapi/mp/ui/OpenApiMpUiExtension.java
@@ -37,6 +37,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import static com.kumuluz.ee.openapi.mp.ui.util.PathUtils.removeTrailingAndAddLeadingSlash;
+import static com.kumuluz.ee.openapi.mp.ui.util.PathUtils.removeTrailingSlashes;
+
 /**
  * OpenAPI MP UI extension. Serves UI on a configured mapping with appropriate parameters.
  *
@@ -48,6 +51,8 @@ import java.util.logging.Logger;
 public class OpenApiMpUiExtension implements Extension {
 
     private static final Logger LOG = Logger.getLogger(OpenApiMpUiExtension.class.getName());
+
+    public static final String OAUTH_HTML_PAGE = "/oauth2-redirect.html";
 
     @Override
     public void init(KumuluzServerWrapper kumuluzServerWrapper, EeConfig eeConfig) {
@@ -64,9 +69,8 @@ public class OpenApiMpUiExtension implements Extension {
             if (uiPath.endsWith("*")) {
                 uiPath = uiPath.substring(0, uiPath.length() - 1);
             }
-            if (uiPath.endsWith("/")) {
-                uiPath = uiPath.substring(0, uiPath.length() - 1);
-            }
+            uiPath = removeTrailingAndAddLeadingSlash(uiPath);
+            specPath = removeTrailingAndAddLeadingSlash(specPath);
 
             if (uiPath.isEmpty()) {
                 // not supported as of yet, probably could be done by very strict redirects in SwaggerUIFilter
@@ -120,9 +124,7 @@ public class OpenApiMpUiExtension implements Extension {
             }
 
             // remove trailing slashes
-            while (serverUrl.endsWith("/")) {
-                serverUrl = serverUrl.substring(0, serverUrl.length() - 1);
-            }
+            serverUrl = removeTrailingSlashes(serverUrl);
 
             // static files for Swagger UI, created by Maven download plugin and Maven copy plugin
             URL webApp = ResourceUtils.class.getClassLoader().getResource("swagger-ui/api-specs/ui");
@@ -153,8 +155,9 @@ public class OpenApiMpUiExtension implements Extension {
                 // create filter that will redirect to Swagger UI with appropriate parameters
                 Map<String, String> swaggerUiFilterParams = new HashMap<>();
                 swaggerUiFilterParams.put("specUrl", specUrl);
+                swaggerUiFilterParams.put("specPath", specPath);
                 swaggerUiFilterParams.put("uiPath", redirUiPath);
-                swaggerUiFilterParams.put("oauth2RedirectUrl", oauth2RedirectUrl + "/oauth2-redirect.html");
+                swaggerUiFilterParams.put("oauth2RedirectUrl", oauth2RedirectUrl + OAUTH_HTML_PAGE);
                 server.registerFilter(SwaggerUIFilter.class, uiPath + "/*", swaggerUiFilterParams);
 
             } else {

--- a/ui/src/main/java/com/kumuluz/ee/openapi/mp/ui/filters/CustomServer.java
+++ b/ui/src/main/java/com/kumuluz/ee/openapi/mp/ui/filters/CustomServer.java
@@ -1,0 +1,71 @@
+package com.kumuluz.ee.openapi.mp.ui.filters;
+
+import org.eclipse.microprofile.openapi.models.servers.Server;
+import org.eclipse.microprofile.openapi.models.servers.ServerVariable;
+import org.eclipse.microprofile.openapi.models.servers.ServerVariables;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Server implementation used to insert generated server into Swagger UI server list.
+ *
+ * @author Michal Vrsansky
+ */
+public class CustomServer implements Server {
+
+    private final String url;
+
+    public CustomServer(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public void setUrl(String url) {
+    }
+
+    @Override
+    public String getDescription() {
+        return "(added by auto-configuration)";
+    }
+
+    @Override
+    public void setDescription(String description) {
+    }
+
+    @Override
+    public ServerVariables getVariables() {
+        return null;
+    }
+
+    @Override
+    public void setVariables(ServerVariables variables) {
+    }
+
+    @Override
+    public void setVariables(Map<String, ServerVariable> variables) {
+    }
+
+    @Override
+    public Map<String, Object> getExtensions() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Server addExtension(String name, Object value) {
+        return this;
+    }
+
+    @Override
+    public void removeExtension(String name) {
+    }
+
+    @Override
+    public void setExtensions(Map<String, Object> extensions) {
+    }
+}

--- a/ui/src/main/java/com/kumuluz/ee/openapi/mp/ui/filters/SwaggerUIFilter.java
+++ b/ui/src/main/java/com/kumuluz/ee/openapi/mp/ui/filters/SwaggerUIFilter.java
@@ -20,11 +20,34 @@
  */
 package com.kumuluz.ee.openapi.mp.ui.filters;
 
-import javax.servlet.*;
+import io.smallrye.openapi.api.OpenApiDocument;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.servers.Server;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+
+import static com.kumuluz.ee.openapi.mp.ui.OpenApiMpUiExtension.OAUTH_HTML_PAGE;
+import static com.kumuluz.ee.openapi.mp.ui.util.PathUtils.removeTrailingAndAddLeadingSlash;
 
 /**
  * Configures default parameters for Swagger UI when coming from root URL.
@@ -35,15 +58,30 @@ import java.util.regex.Pattern;
  */
 public class SwaggerUIFilter implements Filter {
 
+    private static final Logger LOG = Logger.getLogger(SwaggerUIFilter.class.getName());
+
+
+    private static final String X_ORIGINAL_URI = "X-Original-URI";
+    private static final String OAUTH_QUERY = "&oauth2RedirectUrl=";
+    private static final String URL_QUERY = "/?url=";
+    private static final List<String> LOCAL_HOST_ALIASES = Arrays.asList("localhost", "loopback", "127.0.0.1", "[::1]");
+
+
     private String specUrl;
     private String uiPath;
     private String oauth2RedirectUrl;
+    private String specPath;
+    private boolean isAutoConfigure;
+    private boolean isServerListUpdateEnabled;
+    private boolean isXURICheckEnabled;
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         this.specUrl = filterConfig.getInitParameter("specUrl");
         this.uiPath = filterConfig.getInitParameter("uiPath");
         this.oauth2RedirectUrl = filterConfig.getInitParameter("oauth2RedirectUrl");
+        this.specPath = filterConfig.getInitParameter("specPath");
+        getServerAutoConfigurationSettings();
     }
 
     @Override
@@ -58,24 +96,148 @@ public class SwaggerUIFilter implements Filter {
         // check if request is for UI
         if (path.contains(uiPath)) {
             // match static files and urls with existing parameter url=... set
-            Pattern staticFiles = Pattern.compile("(\\.css|\\.js|\\.html|url=)");
+            Pattern staticFiles = Pattern.compile("(\\.css|\\.js|\\.html|\\.png|url=)");
             String requestQueryString = httpServletRequest.getRequestURI();
             if (httpServletRequest.getQueryString() != null) {
                 requestQueryString += httpServletRequest.getQueryString();
             }
             if (!staticFiles.matcher(requestQueryString).find()) {
-                // not a static file, redirect to appropriate url
-                httpServletResponse.sendRedirect(uiPath +
-                        "/?url=" + specUrl +
-                        "&oauth2RedirectUrl=" + oauth2RedirectUrl);
+                // not a static file, redirect to appropriate url, if enabled perform auto-configuration
+                String redirectUrl = isAutoConfigure ? createRedirectPathFromRequest(httpServletRequest) : getStaticRedirect();
+                httpServletResponse.sendRedirect(redirectUrl);
             } else {
                 // static file, leave as is
                 filterChain.doFilter(httpServletRequest, httpServletResponse);
             }
-
         } else {
             filterChain.doFilter(servletRequest, servletResponse);
         }
+    }
+
+    private String getStaticRedirect() {
+        return uiPath + URL_QUERY + specUrl + OAUTH_QUERY + oauth2RedirectUrl;
+    }
+
+    private String createRedirectPathFromRequest(HttpServletRequest httpServletRequest) {
+        try {
+            Request request = ((Request) httpServletRequest);
+            // gather URL and other information from http request
+            String rootPath = getRootPath(request);
+            URI rootURI = URI.create(getRootUrl(request) + rootPath);
+
+            // update server list if enabled
+            if (isServerListUpdateEnabled) {
+                updateServerList(rootURI);
+            }
+
+            String rootUrl = rootURI.toString();
+            return rootPath + uiPath + URL_QUERY + rootUrl + specPath + OAUTH_QUERY + rootUrl + uiPath + OAUTH_HTML_PAGE;
+        } catch (Exception e) {
+            LOG.warning("Failed to dynamically resolve redirect from request header, " +
+                                "falling back to static configuration. Reason of failure: " + e.getMessage());
+            return getStaticRedirect();
+        }
+    }
+
+    private String getRootUrl(Request request) {
+        // note: maybe compose root url from header too when isXURICheckEnable true (X-Forwarded-Host, X-Forwarded-Proto)
+        return request.getRootURL().toString();
+    }
+
+    private String getRootPath(Request request) {
+        if (isXURICheckEnabled) {
+            // retrieve X-Original-URI if available
+            String originalURI = request.getHeader(X_ORIGINAL_URI);
+            if (originalURI != null) {
+                // remove uiPath part (which is contained in X-Org... path provided by ingres for example)
+                String rootPathFromHeader = originalURI.replaceFirst(uiPath + ".*\\z", "");
+                return removeTrailingAndAddLeadingSlash(rootPathFromHeader);
+            }
+        }
+
+        return "";
+    }
+
+    /**
+     * Updates Open API servers list.
+     * If URL is already in list or it is loopback address then no action is taken.
+     */
+    private synchronized void updateServerList(URI rootURI) {
+        OpenAPI openApiDocument = getOpenAPI();
+
+        List<Server> oldServers =
+                Optional.ofNullable(openApiDocument.getServers()).orElse(Collections.emptyList());
+
+        // update server list and in case where server was add also move it to the top
+        if (isNotInServerList(rootURI, oldServers)) {
+            // note: there is possibility that simultaneous getting of openapi .json and invoking
+            // ui endpoint will result in 2 different lists of servers
+            ArrayList<Server> newServers = new ArrayList<>();
+            newServers.add(new CustomServer(rootURI.toString()));
+            newServers.addAll(oldServers);
+            openApiDocument.setServers(newServers);
+        }
+    }
+
+    private boolean isNotInServerList(URI rootURI, List<Server> oldServers) {
+        boolean isRootUrlLoopback = isLoopbackHost(rootURI.getHost());
+        return oldServers
+                .stream()
+                // first check if servers are match,then compare if urls are loopback and are matched
+                .noneMatch(s -> rootURI.toString().equalsIgnoreCase(s.getUrl()) ||
+                            isRootUrlLoopback && isLoopbackUrl(s.getUrl()));
+    }
+
+    private void getServerAutoConfigurationSettings() {
+        // gather config
+        ConfigurationUtil configurationUtil = getConfigUtil();
+        this.isAutoConfigure = configurationUtil
+                .getBoolean("kumuluzee.openapi-mp.ui.server-auto-config.enabled")
+                .orElse(false);
+        this.isServerListUpdateEnabled = configurationUtil
+                .getBoolean("kumuluzee.openapi-mp.ui.server-auto-config.update-servers")
+                .orElse(true);
+        this.isXURICheckEnabled = configurationUtil
+                .getBoolean("kumuluzee.openapi-mp.ui.server-auto-config.original-uri-check")
+                .orElse(false);
+    }
+
+    /**
+     * Determines if supplied host is loopback address or not.
+     */
+    public static boolean isLoopbackHost(String host) {
+        if (host == null || host.isEmpty()) {
+            return false;
+        }
+
+        String lowerCaseHost = host.toLowerCase();
+        return LOCAL_HOST_ALIASES.stream().anyMatch(lowerCaseHost::startsWith);
+    }
+
+    /**
+     * Determines if supplied host is loopback address or not.
+     */
+    public static boolean isLoopbackUrl(String uri) {
+        if (uri == null || uri.isEmpty()) {
+            return false;
+        }
+
+        try {
+            return isLoopbackHost(URI.create(uri).getHost());
+        } catch (SecurityException | IllegalArgumentException e) {
+            // exception is not important, its just hint to return false so logging is omitted
+            return false;
+        }
+    }
+
+    @VisibleForTesting
+    ConfigurationUtil getConfigUtil() {
+        return ConfigurationUtil.getInstance();
+    }
+
+    @VisibleForTesting
+    OpenAPI getOpenAPI() {
+        return OpenApiDocument.INSTANCE.get();
     }
 
     @Override

--- a/ui/src/main/java/com/kumuluz/ee/openapi/mp/ui/util/PathUtils.java
+++ b/ui/src/main/java/com/kumuluz/ee/openapi/mp/ui/util/PathUtils.java
@@ -1,0 +1,54 @@
+package com.kumuluz.ee.openapi.mp.ui.util;
+
+/**
+ * Utility class to aid path normalization like removing of trailing slashes and so.
+ *
+ * @author Michal Vrsansky
+ */
+public class PathUtils {
+
+    private PathUtils() {
+    }
+
+    /**
+     * Add leading '/' if missing and removes trailing '/'.
+     *
+     * @param pathToNormalize path to be normalized
+     * @return corrected path
+     */
+    public static String removeTrailingAndAddLeadingSlash(String pathToNormalize) {
+        if (pathToNormalize == null || pathToNormalize.isEmpty()) {
+            return pathToNormalize;
+        }
+
+        String normalizedPath = pathToNormalize;
+
+        normalizedPath = removeTrailingSlashes(normalizedPath);
+
+        if (!normalizedPath.startsWith("/")) {
+            normalizedPath += "/";
+        }
+
+        return normalizedPath;
+    }
+
+    /**
+     * Removes trailing '/'.
+     *
+     * @param pathToNormalize path to be normalized
+     * @return corrected path
+     */
+    public static String removeTrailingSlashes(String pathToNormalize) {
+        if (pathToNormalize == null || pathToNormalize.isEmpty()) {
+            return pathToNormalize;
+        }
+
+        String normalizedPath = pathToNormalize;
+
+        while (normalizedPath.endsWith("/")) {
+            normalizedPath = normalizedPath.substring(0, normalizedPath.length() - 1);
+        }
+
+        return normalizedPath;
+    }
+}

--- a/ui/src/test/java/com/kumuluz/ee/openapi/mp/ui/filters/SwaggerUIFilterAutoConfigTest.java
+++ b/ui/src/test/java/com/kumuluz/ee/openapi/mp/ui/filters/SwaggerUIFilterAutoConfigTest.java
@@ -1,0 +1,271 @@
+package com.kumuluz.ee.openapi.mp.ui.filters;
+
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.servers.Server;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class SwaggerUIFilterAutoConfigTest {
+
+    private static final Optional<Boolean> TRUE_OPTIONAL = Optional.of(true);
+    private static final Optional<Boolean> FALSE_OPTIONAL = Optional.of(false);
+    private static final Optional<Boolean> DEFAULT_VALUE_OPTIONAL = Optional.empty();
+
+    private static final String URL_QUERY = "/?url=";
+    private static final String URL_OA_QUERY = "&oauth2RedirectUrl=";
+
+    private static final String AUTO_CONFIG_SWITCH = "kumuluzee.openapi-mp.ui.server-auto-config.enabled";
+    private static final String UPDATE_SERVERS_SWITCH = "kumuluzee.openapi-mp.ui.server-auto-config.update-servers";
+    private static final String ORIGINAL_URI_CHECK_SWITCH = "kumuluzee.openapi-mp.ui.server-auto-config.original-uri-check";
+
+    private static final String SPEC_URL_PARAMETER = "specUrl";
+    private static final String UI_PATH_PARAMETER = "uiPath";
+    private static final String OAUTH_REDIRECT_URL_PARAMETER = "oauth2RedirectUrl";
+    private static final String SPEC_PATH_PARAMETER = "specPath";
+
+    private static final String SERVER = "http://server.org";
+    private static final String UI_PATH = "/default/ui";
+    private static final String SPEC_URL = SERVER + "/oa-specification";
+    private static final String SPEC_PATH = "/oa-specification";
+    private static final String OA_HTML = "/oauth2-redirect.html";
+    private static final String OA_REDIRECT_URL = SERVER + UI_PATH + OA_HTML;
+
+    private static final String API_SERVER_A = "http://localhost:8080";
+    private static final String API_SERVER_B = "http://kube-server:1234";
+
+    private static final String HTTP_SERVER = "http://external-server.org:8090";
+    private static final String XPATH = "/ingress-path";
+    private static final String X_ORIGINAL_URI = "X-Original-URI";
+
+    private static final String REQUEST_URI = HTTP_SERVER + UI_PATH;
+
+    @Spy
+    private SwaggerUIFilter swaggerUIFilterSpy;
+    @Mock
+    private ConfigurationUtil configurationUtilMock;
+    @Mock
+    private OpenAPI openAPIMock;
+    @Mock
+    private FilterConfig filterConfigMock;
+    @Mock
+    private FilterChain filterChainMock;
+    @Mock
+    private HttpServletResponse servletResponseMock;
+    @Mock
+    private Request servletRequestMock;
+
+    private List<Server> serverList;
+    private String redirectedUrl;
+
+    @BeforeMethod
+    public void beforeMethod() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        doReturn(configurationUtilMock).when(swaggerUIFilterSpy).getConfigUtil();
+        doReturn(openAPIMock).when(swaggerUIFilterSpy).getOpenAPI();
+        setupConfigMocks();
+        setupServerList();
+        setupServletRequestMock();
+        setupServletResponseMock();
+    }
+
+    @Test
+    public void redirectingWhileAutoConfigIsDisabled() throws Exception {
+        swaggerUIFilterSpy.init(filterConfigMock);
+        swaggerUIFilterSpy.doFilter(servletRequestMock, servletResponseMock, filterChainMock);
+
+        verify(swaggerUIFilterSpy).getConfigUtil();
+        assertThat(redirectedUrl)
+                .isEqualTo(UI_PATH + URL_QUERY + SPEC_URL + URL_OA_QUERY + OA_REDIRECT_URL);
+
+        verify(servletRequestMock, never()).getRootURL();
+        verify(swaggerUIFilterSpy, never()).getOpenAPI();
+        verify(filterChainMock, never()).doFilter(servletRequestMock, servletResponseMock);
+    }
+
+    @Test
+    public void redirectWithStaticConfigUponDynamicResolutionFailure() throws Exception {
+        doReturn(TRUE_OPTIONAL).when(configurationUtilMock).getBoolean(AUTO_CONFIG_SWITCH);
+        doThrow(new RuntimeException()).when(servletRequestMock).getRootURL();
+
+        swaggerUIFilterSpy.init(filterConfigMock);
+        swaggerUIFilterSpy.doFilter(servletRequestMock, servletResponseMock, filterChainMock);
+
+        verify(servletRequestMock).getRootURL();
+        assertThat(redirectedUrl).isEqualTo(UI_PATH + URL_QUERY + SPEC_URL + URL_OA_QUERY + OA_REDIRECT_URL);
+    }
+
+    @Test
+    public void redirectingWhileAutoConfigIsEnabled() throws Exception {
+        doReturn(TRUE_OPTIONAL).when(configurationUtilMock).getBoolean(AUTO_CONFIG_SWITCH);
+
+        swaggerUIFilterSpy.init(filterConfigMock);
+        swaggerUIFilterSpy.doFilter(servletRequestMock, servletResponseMock, filterChainMock);
+
+        verify(swaggerUIFilterSpy).getConfigUtil();
+        assertThat(redirectedUrl)
+                .isEqualTo(UI_PATH + URL_QUERY + HTTP_SERVER + SPEC_PATH + URL_OA_QUERY + HTTP_SERVER + UI_PATH + OA_HTML);
+
+        verify(servletRequestMock).getRootURL();
+        verify(swaggerUIFilterSpy).getOpenAPI();
+        verify(filterChainMock, never()).doFilter(servletRequestMock, servletResponseMock);
+        assertThat(getStringServerList()).containsExactly(HTTP_SERVER, API_SERVER_A, API_SERVER_B);
+    }
+
+    @DataProvider(name = "localHost")
+    public Object[][] localHostDataProvider() {
+        return new Object[][]{{"http://localhost:8080"}, {"http://127.0.0.1:8080"}, {"http://[::1]:8080"}};
+    }
+
+    @Test(dataProvider = "localHost")
+    public void redirectingWhenDynamicServerIsLoopbackServerAndIsAlreadyInServerList(
+            String localHost) throws Exception {
+        doReturn(TRUE_OPTIONAL).when(configurationUtilMock).getBoolean(AUTO_CONFIG_SWITCH);
+        doReturn(new StringBuilder(localHost)).when(servletRequestMock).getRootURL();
+
+        swaggerUIFilterSpy.init(filterConfigMock);
+        swaggerUIFilterSpy.doFilter(servletRequestMock, servletResponseMock, filterChainMock);
+
+        assertThat(redirectedUrl)
+                .isEqualTo(UI_PATH + URL_QUERY + localHost + SPEC_PATH + URL_OA_QUERY + localHost + UI_PATH + OA_HTML);
+
+        assertThat(getStringServerList()).containsExactly(API_SERVER_A, API_SERVER_B);
+    }
+
+    @Test
+    public void redirectingWhenDynamicServerIsLoopbackServerAndIsNotInServerList() throws Exception {
+        String localHost = "http://[::1]:8080";
+        doReturn(TRUE_OPTIONAL).when(configurationUtilMock).getBoolean(AUTO_CONFIG_SWITCH);
+        doReturn(new StringBuilder(localHost)).when(servletRequestMock).getRootURL();
+        serverList.remove(0);
+
+        swaggerUIFilterSpy.init(filterConfigMock);
+        swaggerUIFilterSpy.doFilter(servletRequestMock, servletResponseMock, filterChainMock);
+
+        assertThat(redirectedUrl)
+                .isEqualTo(UI_PATH + URL_QUERY + localHost + SPEC_PATH + URL_OA_QUERY + localHost + UI_PATH + OA_HTML);
+
+        assertThat(getStringServerList()).containsExactly(localHost, API_SERVER_B);
+    }
+
+    @DataProvider(name = "xPath")
+    public Object[][] xPathProvider() {
+        return new Object[][]{{XPATH + UI_PATH + "/random-path"}, {XPATH + UI_PATH + "//"}, {XPATH + UI_PATH}};
+    }
+
+    @Test(dataProvider = "xPath")
+    public void redirectingWithPresentXPath(String xPath) throws Exception {
+        doReturn(TRUE_OPTIONAL).when(configurationUtilMock).getBoolean(AUTO_CONFIG_SWITCH);
+        doReturn(TRUE_OPTIONAL).when(configurationUtilMock).getBoolean(ORIGINAL_URI_CHECK_SWITCH);
+        doReturn(xPath).when(servletRequestMock).getHeader(X_ORIGINAL_URI);
+
+        swaggerUIFilterSpy.init(filterConfigMock);
+        swaggerUIFilterSpy.doFilter(servletRequestMock, servletResponseMock, filterChainMock);
+
+        assertThat(redirectedUrl)
+                .isEqualTo(XPATH + UI_PATH + URL_QUERY + HTTP_SERVER + XPATH + SPEC_PATH + URL_OA_QUERY + HTTP_SERVER + XPATH + UI_PATH + OA_HTML);
+        assertThat(getStringServerList()).containsExactly(HTTP_SERVER + XPATH, API_SERVER_A, API_SERVER_B);
+    }
+
+    @Test
+    public void redirectingWithPresentXPathWhichIsDisbledInConfig() throws Exception {
+        doReturn(TRUE_OPTIONAL).when(configurationUtilMock).getBoolean(AUTO_CONFIG_SWITCH);
+        doReturn(FALSE_OPTIONAL).when(configurationUtilMock).getBoolean(ORIGINAL_URI_CHECK_SWITCH);
+        doReturn(XPATH).when(servletRequestMock).getHeader(X_ORIGINAL_URI);
+
+        swaggerUIFilterSpy.init(filterConfigMock);
+        swaggerUIFilterSpy.doFilter(servletRequestMock, servletResponseMock, filterChainMock);
+
+        assertThat(redirectedUrl)
+                .isEqualTo(UI_PATH + URL_QUERY + HTTP_SERVER + SPEC_PATH + URL_OA_QUERY + HTTP_SERVER + UI_PATH + OA_HTML);
+        assertThat(getStringServerList()).containsExactly(HTTP_SERVER, API_SERVER_A, API_SERVER_B);
+    }
+
+    @Test
+    public void dynamicServerIsAlreadyInListTest() throws Exception {
+        doReturn(TRUE_OPTIONAL).when(configurationUtilMock).getBoolean(AUTO_CONFIG_SWITCH);
+        serverList.add(new CustomServer(HTTP_SERVER));
+
+        swaggerUIFilterSpy.init(filterConfigMock);
+        swaggerUIFilterSpy.doFilter(servletRequestMock, servletResponseMock, filterChainMock);
+
+        assertThat(getStringServerList()).containsExactly(API_SERVER_A, API_SERVER_B, HTTP_SERVER);
+    }
+
+    @Test
+    public void dynamicRedirectingWithDisabledUpdateOfServerList() throws Exception {
+        doReturn(TRUE_OPTIONAL).when(configurationUtilMock).getBoolean(AUTO_CONFIG_SWITCH);
+        doReturn(FALSE_OPTIONAL).when(configurationUtilMock).getBoolean(UPDATE_SERVERS_SWITCH);
+
+        swaggerUIFilterSpy.init(filterConfigMock);
+        swaggerUIFilterSpy.doFilter(servletRequestMock, servletResponseMock, filterChainMock);
+
+        assertThat(redirectedUrl)
+                .isEqualTo(UI_PATH + URL_QUERY + HTTP_SERVER + SPEC_PATH + URL_OA_QUERY + HTTP_SERVER + UI_PATH + OA_HTML);
+
+        assertThat(getStringServerList()).containsExactly(API_SERVER_A, API_SERVER_B);
+    }
+
+    // mocks setup
+    private void setupServletRequestMock() {
+        doReturn(REQUEST_URI).when(servletRequestMock).getRequestURI();
+        doReturn(UI_PATH).when(servletRequestMock).getServletPath();
+        doReturn(new StringBuilder(HTTP_SERVER)).when(servletRequestMock).getRootURL();
+        doReturn("").when(servletRequestMock).getContextPath();
+    }
+
+    private void setupServletResponseMock() throws Exception {
+        doAnswer(invocation -> {
+            redirectedUrl = invocation.getArgument(0);
+            return null;
+        }).when(servletResponseMock).sendRedirect(anyString());
+    }
+
+    private void setupConfigMocks() {
+        doReturn(DEFAULT_VALUE_OPTIONAL).when(configurationUtilMock).getBoolean(AUTO_CONFIG_SWITCH);
+        doReturn(DEFAULT_VALUE_OPTIONAL).when(configurationUtilMock).getBoolean(UPDATE_SERVERS_SWITCH);
+        doReturn(DEFAULT_VALUE_OPTIONAL).when(configurationUtilMock).getBoolean(ORIGINAL_URI_CHECK_SWITCH);
+
+        doReturn(UI_PATH).when(filterConfigMock).getInitParameter(UI_PATH_PARAMETER);
+        doReturn(OA_REDIRECT_URL).when(filterConfigMock).getInitParameter(OAUTH_REDIRECT_URL_PARAMETER);
+        doReturn(SPEC_PATH).when(filterConfigMock).getInitParameter(SPEC_PATH_PARAMETER);
+        doReturn(SPEC_URL).when(filterConfigMock).getInitParameter(SPEC_URL_PARAMETER);
+    }
+
+    private void setupServerList() {
+        serverList = new ArrayList<>();
+        serverList.add(new CustomServer(API_SERVER_A));
+        serverList.add(new CustomServer(API_SERVER_B));
+        doReturn(serverList).when(openAPIMock).getServers();
+        doAnswer(invocationOnMock -> {
+            serverList = invocationOnMock.getArgument(0);
+            return null;
+        }).when(openAPIMock).setServers(anyList());
+    }
+
+    private List<String> getStringServerList() {
+        return serverList.stream().map(Server::getUrl).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Feature which allows to automatically configure redirect parameters for Swagger UI even when 'behind' Ingres. No need to configure servers and paths for UI, just enalbe feature and rest is done by library for you.

- disabled by default in order to not break existing implementations
- automatically updates list of servers in OpenApi definition