### PR TITLE
Raised swagger UI version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <microprofile-openapi.version>1.1.2</microprofile-openapi.version>
         <smallrye-open-api.version>2.0.14</smallrye-open-api.version>
         <classgraph.version>4.8.90</classgraph.version>
-        <swagger-ui.version>3.36.1</swagger-ui.version>
+        <swagger-ui.version>3.46.0</swagger-ui.version>
         <maven-project.version>2.2.1</maven-project.version>
 
         <testng.version>6.9.9</testng.version>


### PR DESCRIPTION
Raised bundled swagger UI version. 

Current version (3.36.1) lacks OpenID Connect Discovery (introduced in 3.38.0).